### PR TITLE
Add support for multiple OIDC providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add support for multiple OIDC providers in the NTH IAM role
+
 ## [1.1.0] - 2024-12-11
 
 ### Added

--- a/helm/aws-nth-crossplane-resources/templates/_helpers.tpl
+++ b/helm/aws-nth-crossplane-resources/templates/_helpers.tpl
@@ -36,3 +36,13 @@ giantswarm.io/service-type: {{ .Values.serviceType }}
 helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}
 
+{{/*
+Get list of all provided OIDC domains
+*/}}
+{{- define "oidcDomains" -}}
+{{- $oidcDomains := list .Values.oidcDomain -}}
+{{- if .Values.oidcDomains -}}
+{{- $oidcDomains = concat $oidcDomains .Values.oidcDomains -}}
+{{- end -}}
+{{- compact $oidcDomains | uniq | toJson -}}
+{{- end -}}

--- a/helm/aws-nth-crossplane-resources/templates/iam.yaml
+++ b/helm/aws-nth-crossplane-resources/templates/iam.yaml
@@ -16,18 +16,21 @@ spec:
       {
         "Version": "2012-10-17",
         "Statement": [
-          {
+          {{- $oidcDomains := include "oidcDomains" . | fromJsonArray -}}
+          {{- range $index, $oidcDomain := $oidcDomains -}}
+          {{- if not (eq $index 0) }}, {{ end }}{
             "Effect": "Allow",
             "Principal": {
-              "Federated": "arn:{{.Values.awsPartition}}:iam::{{.Values.accountID}}:oidc-provider/{{.Values.oidcDomain}}"
+              "Federated": "arn:{{.Values.awsPartition}}:iam::{{.Values.accountID}}:oidc-provider/{{$oidcDomain}}"
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
               "StringLike": {
-                "{{.Values.oidcDomain}}:sub": "system:serviceaccount:kube-system:aws-node-termination-handler"
+                "{{$oidcDomain}}:sub": "system:serviceaccount:kube-system:aws-node-termination-handler"
               }
             }
           }
+          {{- end }}
         ]
       }
     inlinePolicy:

--- a/helm/aws-nth-crossplane-resources/values.schema.json
+++ b/helm/aws-nth-crossplane-resources/values.schema.json
@@ -29,7 +29,10 @@
             "type": "string"
         },
         "oidcDomains": {
-            "type": "array"
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         },
         "project": {
             "type": "object",


### PR DESCRIPTION
Clusters can now define multiple OIDC providers, and the NTH IAM role should allow them all

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
