### PR TITLE
Add permissions `autoscaling:DescribeLifecycleHooks` and `autoscaling:RecordLifecycleActionHeartbeat` because aws-node-termination-handler needs them for the heartbeat sending feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add permissions `autoscaling:DescribeLifecycleHooks` and `autoscaling:RecordLifecycleActionHeartbeat` because aws-node-termination-handler needs them for the heartbeat sending feature
+
 ### Fixed
 
 - Fix rendering of OIDC providers in Helm template

--- a/helm/aws-nth-crossplane-resources/templates/iam.yaml
+++ b/helm/aws-nth-crossplane-resources/templates/iam.yaml
@@ -45,7 +45,9 @@ spec:
                 "Action": [
                   "autoscaling:CompleteLifecycleAction",
                   "autoscaling:DescribeAutoScalingInstances",
+                  "autoscaling:DescribeLifecycleHooks",
                   "autoscaling:DescribeTags",
+                  "autoscaling:RecordLifecycleActionHeartbeat",
                   "ec2:DescribeInstances",
                   "sqs:DeleteMessage",
                   "sqs:ReceiveMessage"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32232