### PR TITLE
Add io.giantswarm.application annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add `io.giantswarm.application.audience: giantswarm` annotation.
-- Migrate chart metadata annotations to `io.giantswarm.application.*` format.
+- Migrate chart metadata annotations to `io.giantswarm.application.*` format, replacing `application.giantswarm.io/team` with `io.giantswarm.application.team`.
+- Add `io.giantswarm.application.audience: all` annotation.
+- Add `io.giantswarm.application.managed: "true"` annotation.
+- Add `io.giantswarm.application.restrictions.compatible-providers: "aws"` annotation.
 
 ## [1.3.2] - 2026-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `io.giantswarm.application.audience: giantswarm` annotation.
+- Migrate chart metadata annotations to `io.giantswarm.application.*` format.
+
 ## [1.3.2] - 2026-02-14
 
 ### Fixed
@@ -29,34 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix rendering of OIDC providers in Helm template
 
-## [1.2.0] - 2025-10-02
-
-### Added
-
-- Add `giantswarm.io/managed-by` tag to AWS Resources.
-
-## [1.1.1] - 2025-04-10
-
-### Changed
-
-- Add support for multiple OIDC providers in the NTH IAM role
-- Included the `giantswarm.io/cluster` label
-
-## [1.1.0] - 2024-12-11
-
-### Added
-
-- Send spot instance interruption and instance state change events to SQS queue so that aws-node-termination-handler can react to them
-
-## [1.0.0] - 2024-10-30
-
-- changed: `app.giantswarm.io` label group was changed to `application.giantswarm.io`
-
 [Unreleased]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.3.2...HEAD
 [1.3.2]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.1.1...v1.2.0
-[1.1.1]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/giantswarm/aws-nth-crossplane-resources/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix rendering of OIDC providers in Helm template
 
+## [1.2.0] - 2025-10-02
+
+### Added
+
+- Add `giantswarm.io/managed-by` tag to AWS Resources.
+
+## [1.1.1] - 2025-04-10
+
+### Changed
+
+- Add support for multiple OIDC providers in the NTH IAM role
+- Included the `giantswarm.io/cluster` label
+
+## [1.1.0] - 2024-12-11
+
+### Added
+
+- Send spot instance interruption and instance state change events to SQS queue so that aws-node-termination-handler can react to them
+
+## [1.0.0] - 2024-10-30
+
+- changed: `app.giantswarm.io` label group was changed to `application.giantswarm.io`
+
 [Unreleased]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.3.2...HEAD
 [1.3.2]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.1.1...v1.2.0
+[1.1.1]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/giantswarm/aws-nth-crossplane-resources/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/giantswarm/aws-nth-crossplane-resources/releases/tag/v1.0.0

--- a/helm/aws-nth-crossplane-resources/Chart.yaml
+++ b/helm/aws-nth-crossplane-resources/Chart.yaml
@@ -8,7 +8,6 @@ sources:
   - https://github.com/giantswarm/aws-nth-crossplane-resources
 version: 1.3.2
 annotations:
-  application.giantswarm.io/team: phoenix
   io.giantswarm.application.audience: all
   io.giantswarm.application.managed: "true"
   io.giantswarm.application.team: phoenix

--- a/helm/aws-nth-crossplane-resources/Chart.yaml
+++ b/helm/aws-nth-crossplane-resources/Chart.yaml
@@ -9,7 +9,7 @@ sources:
 version: 1.3.2
 annotations:
   application.giantswarm.io/team: phoenix
-  io.giantswarm.application.audience: giantswarm
+  io.giantswarm.application.audience: all
   io.giantswarm.application.managed: "true"
   io.giantswarm.application.team: phoenix
   io.giantswarm.application.restrictions.compatible-providers: "aws"

--- a/helm/aws-nth-crossplane-resources/Chart.yaml
+++ b/helm/aws-nth-crossplane-resources/Chart.yaml
@@ -9,3 +9,7 @@ sources:
 version: 1.3.2
 annotations:
   application.giantswarm.io/team: phoenix
+  io.giantswarm.application.audience: giantswarm
+  io.giantswarm.application.managed: "true"
+  io.giantswarm.application.team: phoenix
+  io.giantswarm.application.restrictions.compatible-providers: "aws"

--- a/helm/aws-nth-crossplane-resources/templates/_helpers.tpl
+++ b/helm/aws-nth-crossplane-resources/templates/_helpers.tpl
@@ -30,7 +30,7 @@ app.giantswarm.io/branch: {{ .Chart.Annotations.branch | replace "#" "-" | repla
 application.giantswarm.io/commit: {{ .Chart.Annotations.commit | quote }}
 application.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 application.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 giantswarm.io/managed-by: {{ .Release.Name | quote }}
 giantswarm.io/service-type: {{ .Values.serviceType }}
 giantswarm.io/cluster: {{ .Values.clusterName | quote }}


### PR DESCRIPTION
Add io.giantswarm.application.audience: giantswarm annotation and migrate chart metadata to io.giantswarm.application.* format.

Backstage is becoming the primary entry point for customers to discover apps. This app is used internally by Giant Swarm and is not intended to be customer-facing.

Relates to giantswarm/giantswarm#35731